### PR TITLE
Add a deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+⚠️ This repository is not maintained. Jira and Confluence dashboards have been moved over to https://github.com/atlassian-labs/data-center-grafana-dashboards
+
 # DC App Monitoring Dashboards
 [![Atlassian license](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 


### PR DESCRIPTION
A monorepo is used to host all the dashboards for DC products https://github.com/atlassian-labs/data-center-grafana-dashboards